### PR TITLE
feat(jobs): 添加每日摄入作业和调度

### DIFF
--- a/TreasureTrove/definitions.py
+++ b/TreasureTrove/definitions.py
@@ -5,12 +5,13 @@ from dagster import (
 )
 from TreasureTrove.io_managers.pandas_io_manager import CsvIOManager
 from TreasureTrove.resources import EnvResource, NasResource
-from TreasureTrove.jobs.demo_jobs import (portfolio_job, financial_db_update_job)
+from TreasureTrove.jobs.ingestion_job import ingestion_daily, ingestion_daily_schedule
 from TreasureTrove import assets
 
 defs = Definitions(
     assets=load_assets_from_package_module(assets),
-    #jobs=[portfolio_job, financial_db_update_job],
+    jobs=[ingestion_daily],
+    schedules=[ingestion_daily_schedule],
     resources={
         "pandas_csv": CsvIOManager(),
         "env": EnvResource(

--- a/TreasureTrove/jobs/ingestion_job.py
+++ b/TreasureTrove/jobs/ingestion_job.py
@@ -1,0 +1,21 @@
+from dagster import define_asset_job, AssetSelection, AssetKey, multiprocess_executor, ScheduleDefinition
+
+
+ingestion_daily = define_asset_job(
+    name="ingestion_daily",
+    selection=AssetSelection.groups("Ingestion")
+    - AssetSelection.assets(
+        AssetKey(["sources", "tushare", "china_index_info"]),
+        AssetKey(["sources", "tushare", "china_index_weight"]),
+        AssetKey(["sources", "ad_hoc", "bars"]),
+    ),
+    executor_def=multiprocess_executor.configured({"max_concurrent": 1}),
+)
+
+
+# Define the schedule
+ingestion_daily_schedule = ScheduleDefinition(
+    job=ingestion_daily,
+    cron_schedule="30 16 * * 1-5",  # Every weekday at 16:30
+    execution_timezone="Asia/Shanghai"  # Beijing time
+)


### PR DESCRIPTION
- 新增 ingestion_daily 作业，用于每日数据集成- 创建 ingestion_daily_schedule 调度，于每个工作日下午 16:30 执行作业- 更新 definitions.py，引入新的作业和调度
- 移除旧的 demo_jobs 引用